### PR TITLE
Implement package actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Added the `hasky-stack-package-action` command allowing to install and
   lookup information about packages.
 
+* Renamed the face `hasky-project-version` to `hasky-stack-project-version`.
+
 ## Hasky Stack 0.2.0
 
 * Fixed the `stack upload` command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Hasky Stack 0.3.0
+
+* Added the `hasky-stack-package-action` command allowing to install and
+  lookup information about packages.
+
 ## Hasky Stack 0.2.0
 
 * Fixed the `stack upload` command.

--- a/hasky-stack.el
+++ b/hasky-stack.el
@@ -213,6 +213,17 @@ failure.  Returned path is guaranteed to have trailing slash."
     (remove "Template"
             (hasky-stack--all-matches "^\\(\\([[:alnum:]]\\|-\\)+\\)"))))
 
+(defun hasky-stack--packages () ;; FIXME this is not going to work!
+  "Return list of all packages in Hackage indices."
+  (mapcar
+   #'f-filename
+   (f-entries
+    (f-expand ".stack/indices/Hackage/packages" "~/") ;; this thing is not
+    ;; untared by stack automatically, we need to deal with actual tar
+    ;; archive somehow. Simplest way would be to untar it manually, then
+    ;; keep checking that the extracted directory is not out-of-date.
+    #'f-directory?)))
+
 (defun hasky-stack--completing-read (prompt &optional collection require-match)
   "Read user's input using `hasky-stack-read-function'.
 
@@ -255,6 +266,7 @@ Finally, if COLLECTION is nil, plain `read-string' is used."
      (cons hasky-stack--project-name
            hasky-stack--project-targets)
      t)))
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Preparation
@@ -676,6 +688,16 @@ obviously template name."
        "--bare"
        project-name
        template))))
+
+;;;###autoload
+(defun hasky-stack-project-action (package)
+  "Open a popup allowing to install or request information about PACKAGE."
+  (interactive
+   (list (hasky-stack--completing-read
+          "Package: "
+          (hasky-stack--packages)
+          t)))
+  (message "%S" package))
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/hasky-stack.el
+++ b/hasky-stack.el
@@ -242,7 +242,10 @@ failure.  Returned path is guaranteed to have trailing slash."
   (f-expand "ts" (hasky-stack--index-dir)))
 
 (defun hasky-stack--ensure-indices ()
-  "Make sure that we have downloaded and untar-ed Hackage package indices."
+  "Make sure that we have downloaded and untar-ed Hackage package indices.
+
+This uses external ‘tar’ command, so it probably won't work on
+Windows."
   (let ((index-file (hasky-stack--index-file))
         (index-dir (hasky-stack--index-dir))
         (index-stamp (hasky-stack--index-stamp-file)))
@@ -257,7 +260,7 @@ failure.  Returned path is guaranteed to have trailing slash."
           (f-mkdir index-dir)
           (let ((default-directory index-dir))
             (message "Extracting Hackage indices, please be patient")
-            (shell-command ;; FIXME probably won't work on Windows
+            (shell-command
              (concat "tar -xf " (shell-quote-argument index-file))))
           (f-touch index-stamp)
           (message "Finished preparing Hackage indices"))
@@ -831,7 +834,13 @@ obviously template name."
 
 ;;;###autoload
 (defun hasky-stack-package-action (package)
-  "Open a popup allowing to install or request information about PACKAGE."
+  "Open a popup allowing to install or request information about PACKAGE.
+
+This functionality currently relies on existence of ‘tar’
+command.  This means that it works on Posix systems, but may have
+trouble working on Windows.  Please let me know if you run into
+any issues on Windows and we'll try to work around (I don't have
+a Windows machine)."
   (interactive
    (list (hasky-stack--completing-read
           "Package: "

--- a/hasky-stack.el
+++ b/hasky-stack.el
@@ -191,6 +191,13 @@ This is used by `hasky-stack--prepare'."
               (hasky-stack--all-matches
                "^[[:blank:]]*benchmark[[:blank:]]+\\([[:word:]-]+\\)"))))))
 
+(defun hasky-stack--home-page-from-cabal-file (filename)
+  "Parse package home page from \"*.cabal\" file with FILENAME."
+  (with-temp-buffer
+    (insert-file-contents filename)
+    (car (hasky-stack--all-matches
+          "^[[:blank:]]*homepage:[[:blank:]]+\\(.+\\)"))))
+
 (defun hasky-stack--find-dir-of-file (regexp)
   "Find file whose name satisfies REGEXP traversing upwards.
 
@@ -752,6 +759,7 @@ This uses `compile' internally."
                (?h "Hackage"      hasky-stack-package-open-hackage)
                (?s "Stackage"     hasky-stack-package-open-stackage)
                (?m "Build matrix" hasky-stack-package-open-build-matrix)
+               (?g "Home page"    hasky-stack-package-open-home-page)
                (?c "Changelog"    hasky-stack-package-open-changelog))
   :default-action 'hasky-stack-package-install
   :max-action-columns 3)
@@ -791,6 +799,18 @@ This uses `compile' internally."
   (browse-url
    (concat "https://matrix.hackage.haskell.org/package/"
            (url-hexify-string package))))
+
+(defun hasky-stack-package-open-home-page (package)
+  "Open home page of PACKAGE."
+  (interactive (list hasky-stack--package-action-package))
+  (let* ((versions (hasky-stack--package-versions package))
+         (latest-version (hasky-stack--latest-version versions))
+         (cabal-file (f-join (hasky-stack--index-dir)
+                             package
+                             latest-version
+                             (concat package ".cabal")))
+         (homepage (hasky-stack--home-page-from-cabal-file cabal-file)))
+    (browse-url homepage)))
 
 (defun hasky-stack-package-open-changelog (package)
   "Open Hackage build matrix for PACKAGE."

--- a/hasky-stack.el
+++ b/hasky-stack.el
@@ -410,8 +410,8 @@ Result is expected to be used as argument of `compile'."
             (remove nil args)))
    " "))
 
-(defun hasky-stack--exec-command (dir command &rest args)
-  "Call target as if from DIR performing COMMAND with arguments ARGS.
+(defun hasky-stack--exec-command (package dir command &rest args)
+  "Call stack for PACKAGE as if from DIR performing COMMAND with arguments ARGS.
 
 Arguments are quoted if necessary and NIL arguments are ignored.
 This uses `compile' internally."
@@ -423,7 +423,7 @@ This uses `compile' internally."
                     (replace-regexp-in-string
                      "[[:space:]]"
                      "-"
-                     hasky-stack--project-name)) ;; FIXME this may be nil
+                     (or package "hasky")))
                    "stack"))))
     (compile (apply #'hasky-stack--format-command command args))
     nil))
@@ -506,6 +506,7 @@ This uses `compile' internally."
          (hasky-stack-build-arguments)))
   (apply
    #'hasky-stack--exec-command
+   hasky-stack--project-name
    hasky-stack--last-directory
    "build"
    target
@@ -518,6 +519,7 @@ This uses `compile' internally."
          (hasky-stack-build-arguments)))
   (apply
    #'hasky-stack--exec-command
+   hasky-stack--project-name
    hasky-stack--last-directory
    "bench"
    target
@@ -530,6 +532,7 @@ This uses `compile' internally."
          (hasky-stack-build-arguments)))
   (apply
    #'hasky-stack--exec-command
+   hasky-stack--project-name
    hasky-stack--last-directory
    "test"
    target
@@ -541,6 +544,7 @@ This uses `compile' internally."
    (list (hasky-stack-build-arguments)))
   (apply
    #'hasky-stack--exec-command
+   hasky-stack--project-name
    hasky-stack--last-directory
    "haddock"
    args))
@@ -561,6 +565,7 @@ This uses `compile' internally."
    (list (hasky-stack-init-arguments)))
   (apply
    #'hasky-stack--exec-command
+   hasky-stack--project-name
    hasky-stack--last-directory
    "init"
    args))
@@ -584,6 +589,7 @@ This uses `compile' internally."
          (hasky-stack-setup-arguments)))
   (apply
    #'hasky-stack--exec-command
+   hasky-stack--project-name
    hasky-stack--last-directory
    "setup"
    (unless (string= ghc-version "implied-by-resolver")
@@ -610,6 +616,7 @@ This uses `compile' internally."
    (list (hasky-stack-upgrade-arguments)))
   (apply
    #'hasky-stack--exec-command
+   hasky-stack--project-name
    hasky-stack--last-directory
    "upgrade"
    args))
@@ -631,6 +638,7 @@ This uses `compile' internally."
    (list (hasky-stack-upload-arguments)))
   (apply
    #'hasky-stack--exec-command
+   hasky-stack--project-name
    hasky-stack--last-directory
    "upload"
    "."
@@ -652,6 +660,7 @@ This uses `compile' internally."
    (list (hasky-stack-sdist-arguments)))
   (apply
    #'hasky-stack--exec-command
+   hasky-stack--project-name
    hasky-stack--last-directory
    "sdist"
    args))
@@ -668,6 +677,7 @@ This uses `compile' internally."
         (cons (match-string 1 cmd)
               (match-string 2 cmd)))
     (hasky-stack--exec-command
+     hasky-stack--project-name
      hasky-stack--last-directory
      (if (string= args "")
          (concat "exec " app)
@@ -686,6 +696,7 @@ This uses `compile' internally."
    (list (hasky-stack-clean-arguments)))
   (apply
    #'hasky-stack--exec-command
+   hasky-stack--project-name
    hasky-stack--last-directory
    "clean"
    (if (member "--full" args)
@@ -721,6 +732,7 @@ This uses `compile' internally."
   "Execute \"stack update\"."
   (interactive)
   (hasky-stack--exec-command
+   hasky-stack--project-name
    hasky-stack--last-directory
    "update"))
 
@@ -753,6 +765,7 @@ This uses `compile' internally."
          (hasky-stack-build-arguments)))
   (apply
    #'hasky-stack--exec-command
+   hasky-stack--package-action-package
    hasky-stack-config-dir
    "install"
    (hasky-stack--package-with-version package version)
@@ -823,13 +836,13 @@ obviously template name."
           t)))
   (if (hasky-stack--prepare)
       (message "The directory is already initialized, it seems")
-    (let ((hasky-stack--project-name project-name))
-      (hasky-stack--exec-command
-       default-directory
-       "new"
-       "--bare"
-       project-name
-       template))))
+    (hasky-stack--exec-command
+     project-name
+     default-directory
+     "new"
+     "--bare"
+     project-name
+     template)))
 
 ;;;###autoload
 (defun hasky-stack-package-action (package)

--- a/hasky-stack.el
+++ b/hasky-stack.el
@@ -280,12 +280,10 @@ Windows."
    (f-entries (f-expand package (hasky-stack--index-dir))
               #'f-directory?)))
 
-(defun hasky-stack--package-latest-version (package)
-  "Return latest version of PACKAGE."
-  ;; FIXME this is incorrect
-  (cl-reduce
-   (lambda (x y) (if (string-greaterp x y) x y))
-   (hasky-stack--package-versions package)))
+(defun hasky-stack--latest-version (versions)
+  "Return latest version from VERSIONS."
+  (cl-reduce (lambda (x y) (if (version< y x) x y))
+             versions))
 
 (defun hasky-stack--package-with-version (package version)
   "Render identifier of PACKAGE with VERSION."
@@ -338,10 +336,10 @@ Finally, if COLLECTION is nil, plain `read-string' is used."
   "Present the user with a choice of PACKAGE version."
   (let ((versions (hasky-stack--package-versions package)))
     (if hasky-stack-auto-newest-version
-        (hasky-stack--package-latest-version package)
+        (hasky-stack--latest-version versions)
       (hasky-stack--completing-read
        (format "Version of %s: " package)
-       (cl-sort versions #'string-greaterp)
+       (cl-sort versions (lambda (x y) (version< y x)))
        t))))
 
 
@@ -789,7 +787,8 @@ This uses `compile' internally."
            (url-hexify-string
             (hasky-stack--package-with-version
              package
-             (hasky-stack--package-latest-version package)))
+             (hasky-stack--latest-version
+              (hasky-stack--package-versions package))))
            "/changelog")))
 
 

--- a/hasky-stack.el
+++ b/hasky-stack.el
@@ -261,7 +261,7 @@ failure.  Returned path is guaranteed to have trailing slash."
              (concat "tar -xf " (shell-quote-argument index-file))))
           (f-touch index-stamp)
           (message "Finished preparing Hackage indices"))
-      (message "Failed to fetch indices, something is wrong!"))))
+      (error "%s" "Failed to fetch indices, something is wrong!"))))
 
 (defun hasky-stack--packages ()
   "Return list of all packages in Hackage indices."
@@ -801,7 +801,7 @@ This uses `compile' internally."
       (if (hasky-stack--prepare)
           (hasky-stack-root-popup)
         (message "Cannot locate ‘.cabal’ file"))
-    (message "Cannot locate Stack executable on this system")))
+    (error "%s" "Cannot locate Stack executable on this system")))
 
 ;;;###autoload
 (defun hasky-stack-new (project-name template)

--- a/hasky-stack.el
+++ b/hasky-stack.el
@@ -422,7 +422,7 @@ This uses `compile' internally."
                     (replace-regexp-in-string
                      "[[:space:]]"
                      "-"
-                     hasky-stack--project-name))
+                     hasky-stack--project-name)) ;; FIXME this may be nil
                    "stack"))))
     (compile (apply #'hasky-stack--format-command command args))
     nil))

--- a/hasky-stack.el
+++ b/hasky-stack.el
@@ -144,7 +144,8 @@ This is used in `hasky-stack-project-action'."
 
 (defun hasky-stack--all-matches (regexp)
   "Return list of all stings matching REGEXP in current buffer."
-  (let (matches)
+  (let (matches
+        (case-fold-search t))
     (goto-char (point-min))
     (while (re-search-forward regexp nil t)
       (push (match-string-no-properties 1) matches))

--- a/hasky-stack.el
+++ b/hasky-stack.el
@@ -59,7 +59,7 @@
   '((t (:inherit font-lock-function-name-face)))
   "Face used to display name of current project.")
 
-(defface hasky-project-version
+(defface hasky-stack-project-version
   '((t (:inherit font-lock-doc-face)))
   "Face used to display version of current project.")
 
@@ -701,7 +701,7 @@ This uses `compile' internally."
                              'face 'hasky-stack-project-name)
                  " "
                  (propertize hasky-stack--project-version
-                             'face 'hasky-project-version)
+                             'face 'hasky-stack-project-version)
                  "\n\n"
                  (propertize "Commands"
                              'face 'magit-popup-heading)))


### PR DESCRIPTION
This adds a new command `hasky-stack-package-action` which will allow to install a package by its name/version combo or query information about a package.